### PR TITLE
Do not create directories if autocreation is enabled on the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ CarrierWave.configure do |config|
   config.storage = :webdav
   config.webdav_server = 'https://your.webdav_server.com/dav' # Your WebDAV url.
   # config.webdav_write_server = 'https://secure.your.webdavserver.com/dav/' # This is an optional attribute. It can save on one server and read from another server. (Contributed by @eychu. Thanks)
+  # config.webdav_autocreates_dirs = true # if automatic directory creation is enabled on the server (disables explicit directory creation)
   config.webdav_username = 'your webdav username'
   config.webdav_password = 'your webdav password'
 end

--- a/lib/carrierwave/storage/webdav.rb
+++ b/lib/carrierwave/storage/webdav.rb
@@ -52,6 +52,7 @@ module CarrierWave
           @password = uploader.webdav_password || ''
           @options = {}
           @options = { basic_auth: { username: @username, password: @password } } if @username
+          @create_dirs = !uploader.webdav_autocreates_dirs
         end
 
         def read
@@ -63,7 +64,10 @@ module CarrierWave
         end
 
         def write(file)
-          mkcol
+          if @create_dirs
+            mkcol
+          end
+
           HTTParty.put(write_url, options.merge({ body: file }))
         end
 

--- a/lib/carrierwave/webdav.rb
+++ b/lib/carrierwave/webdav.rb
@@ -8,9 +8,9 @@ class CarrierWave::Uploader::Base
   add_config :webdav_password
   add_config :webdav_server
   add_config :webdav_write_server
+  add_config :webdav_autocreates_dirs
 
   configure do |config|
     config.storage_engines[:webdav] = 'CarrierWave::Storage::WebDAV'
   end
 end
-


### PR DESCRIPTION
Hello :)

I started using your library in our company project.

I noticed that it tries to explicitly create all directories every time. However, in our `nginx.conf`, we have this directive for the WebDAV share: `create_full_put_path on;`. So there's actually no need to create any directories prior to issuing the PUT request.

I hope that this change helps lighten server load a bit.

Thank you.
