### PR TITLE
Check directory existence and skip creation if needed

### DIFF
--- a/lib/carrierwave/httparty_monkey.rb
+++ b/lib/carrierwave/httparty_monkey.rb
@@ -8,12 +8,18 @@ module HTTParty
 
   class Request
     SupportedHTTPMethods << Net::HTTP::Mkcol
+    SupportedHTTPMethods << Net::HTTP::Propfind
   end
 
   module ClassMethods
     # Perform a MKCOL request to a path
     def mkcol(path, options = {}, &block)
       perform_request Net::HTTP::Mkcol, path, options, &block
+    end
+
+    # Perform a PROPFIND request to a path
+    def propfind(path, options = {}, &block)
+      perform_request Net::HTTP::Propfind, path, options, &block
     end
   end
 
@@ -24,5 +30,8 @@ module HTTParty
   def self.mkcol(*args, &block)
     Basement.mkcol(*args, &block)
   end
-end # HTTParty
 
+  def self.propfind(*args, &block)
+    Basement.propfind(*args, &block)
+  end
+end # HTTParty

--- a/lib/carrierwave/webdav/file.rb
+++ b/lib/carrierwave/webdav/file.rb
@@ -99,6 +99,9 @@ module CarrierWave
         end # Make path like a/b/c/t.txt to array ['/a', '/a/b', '/a/b/c']
         use_server = @write_server ? @write_server : server
         dirs.each do |dir|
+          # skip if dir already exists
+          next if HTTParty.propfind("#{use_server}#{dir}", options).code == 207
+
           res = HTTParty.mkcol("#{use_server}#{dir}", options)
           unless [200, 201, 207, 409].include? res.code
             raise CarrierWave::IntegrityError.new("Can't create a new collection: #{res.inspect}")

--- a/lib/carrierwave/webdav/version.rb
+++ b/lib/carrierwave/webdav/version.rb
@@ -1,5 +1,5 @@
 module CarrierWave
   module WebDAV
-    VERSION = "0.5.0"
+    VERSION = "0.5.1"
   end
 end


### PR DESCRIPTION
There are WebDAV servers where the "automatic directory creation" cannot be set. In such cases cannot upload more files to the same directory if the direcotry didn't exists yet.

A simple solution is to check the directory existence before creating it. In WebDAV framework this action can be done by PROPFIND request (retrieves 207 if exists).