### PR TITLE
Don't load upload file content in memory when storing/caching

### DIFF
--- a/lib/carrierwave/storage/webdav.rb
+++ b/lib/carrierwave/storage/webdav.rb
@@ -16,7 +16,7 @@ module CarrierWave
       #
       def cache!(file)
         cached = build_webdav_file(uploader.cache_path)
-        cached.write(file.read)
+        cached.write(file)
         cached
       end
 
@@ -65,7 +65,7 @@ module CarrierWave
       #
       def store!(file)
         stored = build_webdav_file(uploader.store_path)
-        stored.write(file.read)
+        stored.write(file)
         stored
       end
 

--- a/lib/carrierwave/webdav/file.rb
+++ b/lib/carrierwave/webdav/file.rb
@@ -59,7 +59,7 @@ module CarrierWave
       end
 
       def length
-        read.bytesize
+        headers.content_length
       end
 
       def content_type

--- a/lib/carrierwave/webdav/file.rb
+++ b/lib/carrierwave/webdav/file.rb
@@ -47,7 +47,7 @@ module CarrierWave
             body_stream: io,
             headers: {
               'Transfer-Encoding' => 'chunked',
-              'Content-Type' => 'application/octet-stream'
+              'Content-Type' => file.content_type
             }
           }))
         end

--- a/lib/carrierwave/webdav/file.rb
+++ b/lib/carrierwave/webdav/file.rb
@@ -42,7 +42,16 @@ module CarrierWave
           res = mkcol
         end
 
-        res = HTTParty.put(write_url, options.merge({ body: file }))
+        ::File.open(file.file, 'rb') do |io|
+          res = HTTParty.put(write_url, options.merge({
+            body_stream: io,
+            headers: {
+              'Transfer-Encoding' => 'chunked',
+              'Content-Type' => 'application/octet-stream'
+            }
+          }))
+        end
+
         if res.code != 201 and res.code != 204
           raise CarrierWave::IntegrityError.new("Can't put a new file: #{res.inspect}")
         end

--- a/spec/lib/webdav_storage_spec.rb
+++ b/spec/lib/webdav_storage_spec.rb
@@ -32,16 +32,16 @@ describe CarrierWave::Storage::WebDAV do
   describe '#cache!' do
     it 'should cache from WebDAV' do
       stub_mkcol @cache_uri
-      stub_put @cache_uri
+      stub_put(@cache_uri, @file.path)
       webdav_file = @storage.cache!(@file)
-      stub_get @cache_uri
+      stub_get(@cache_uri, @file.path)
       expect(@file.read).to eq(webdav_file.read)
     end
   end
 
   describe '#retrieve_from_cache!' do
     it 'should retreive a cache file from WebDAV' do
-      stub_get @cache_uri
+      stub_get(@cache_uri, @file.path)
       webdav_file = @storage.retrieve_from_cache!('tmp_test.txt')
       expect(@file.read).to eq(webdav_file.read)
     end
@@ -57,17 +57,17 @@ describe CarrierWave::Storage::WebDAV do
 
   it 'should store from WebDAV' do
     stub_mkcol @uri
-    stub_put @uri
+    stub_put(@uri, @file.path)
     webdav_file = @storage.store!(@file)
-    stub_get @uri
+    stub_get(@uri, @file.path)
     expect(@file.read).to eq(webdav_file.read)
   end
 
   it 'should retrieve a file from WebDAV' do
     stub_mkcol @uri
-    stub_put @uri
+    stub_put(@uri, @file.path)
     webdav_file = @storage.store!(@file)
-    stub_get @uri
+    stub_get(@uri, @file.path)
     retrieved_file = @storage.retrieve!(webdav_file)
     expect(@file.read).to eq(retrieved_file.read)
     expect(File.basename(@file.path)).to eq(File.basename(retrieved_file.path))
@@ -75,7 +75,7 @@ describe CarrierWave::Storage::WebDAV do
 
   it 'should delete a file from WebDAV' do
     stub_mkcol @uri
-    stub_put @uri
+    stub_put(@uri, @file.path)
     webdav_file = @storage.store!(@file)
     stub_delete @uri
     expect(Net::HTTPOK).to eq(webdav_file.delete.response.class)
@@ -83,23 +83,23 @@ describe CarrierWave::Storage::WebDAV do
 
   it 'should size equal' do
     stub_mkcol @uri
-    stub_put @uri
+    stub_put(@uri, @file.path)
     webdav_file = @storage.store!(@file)
-    stub_get @uri
+    stub_head(@uri, @file.path)
     expect(@file.size).to eq(webdav_file.size)
   end
 
   it 'assigns file content type to attribute' do
     stub_mkcol @uri
-    stub_put @uri
+    stub_put(@uri, @file.path)
     webdav_file = @storage.store!(@file)
-    stub_head @uri
+    stub_head(@uri, @file.path)
     expect(@file.content_type).to eq(webdav_file.content_type)
   end
 
   it 'should url equal' do
     stub_mkcol @uri
-    stub_put @uri
+    stub_put(@uri, @file.path)
     webdav_file = @storage.store!(@file)
     expect("#{@uploader.webdav_server}/#{@uploader.store_path}").to eq(webdav_file.url)
   end
@@ -126,10 +126,10 @@ describe CarrierWave::Storage::WebDAV do
       # secure_uri.password = @uploader.webdav_password
 
       stub_mkcol secure_uri
-      stub_put secure_uri
+      stub_put(secure_uri, @file.path)
       webdav_file = @storage.store!(@file)
 
-      stub_get @uri
+      stub_get(@uri, @file.path)
       expect(@file.read).to eq(webdav_file.read)
     end
   end

--- a/spec/lib/webdav_storage_spec.rb
+++ b/spec/lib/webdav_storage_spec.rb
@@ -18,6 +18,7 @@ describe CarrierWave::Storage::WebDAV do
 
     @storage = CarrierWave::Storage::WebDAV.new(@uploader)
     @file = CarrierWave::SanitizedFile.new(file_path('test.txt'))
+    @file.content_type = 'text/plain'
 
     # NOTE: specs fail with this options
     #

--- a/spec/supports/helpers.rb
+++ b/spec/supports/helpers.rb
@@ -1,22 +1,39 @@
+require 'mime/types'
+
 module Helpers
 
   def file_path( *paths )
     File.expand_path(File.join(File.dirname(__FILE__), '../fixtures', *paths))
   end
 
-  def stub_get(url)
+  def mime_type(path)
+    ::MIME::Types.type_for(path).first.to_s
+  end
+
+  def file_response(path)
+    {
+      :status => 200,
+      :body => File.read(path),
+      :headers => {
+        'Content-Type' => mime_type(path),
+        'Content-Length' => File.size(path).to_s
+      }
+    }
+  end
+
+  def stub_get(url, path)
     stub_request(:get, url.to_s).
-        to_return(:status => 200, :body => 'Hello, this is test data.', :headers => {})
+        to_return(file_response(path))
   end
 
-  def stub_head(url)
+  def stub_head(url, path)
     stub_request(:head, url.to_s).
-        to_return(:status => 200, :body => '', :headers => {'Content-type' => 'text/plain'})
+        to_return(file_response(path))
   end
 
-  def stub_put(url)
+  def stub_put(url, path)
     stub_request(:put, url.to_s).
-        with(:body => 'Hello, this is test data.').
+        with(:body => File.read(path)).
         to_return(:status => 201, :body => '', :headers => {})
   end
 


### PR DESCRIPTION
This carrierwave adapter currently loads the uploaded file contents in memory in order to send it to webdav or return its size.
This PR fixes that by leveraging HTTParty's body_stream (which in turn uses net/http body_stream) to send it chunk by chunk instead, and to use Content-Length headers for the size.